### PR TITLE
Support for generic editor extensions

### DIFF
--- a/plugins/org.brainwy.liclipsetext.editor/META-INF/MANIFEST.MF
+++ b/plugins/org.brainwy.liclipsetext.editor/META-INF/MANIFEST.MF
@@ -24,7 +24,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.console,
  org.eclipse.core.filesystem,
  org.eclipse.e4.core.commands;resolution:=optional,
- com.ibm.icu
+ com.ibm.icu,
+ org.eclipse.core.expressions;bundle-version="3.5.100",
+ org.eclipse.ui.genericeditor;bundle-version="1.0.0";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: com.eclipsesource.json,

--- a/plugins/org.brainwy.liclipsetext.editor/plugin.xml
+++ b/plugins/org.brainwy.liclipsetext.editor/plugin.xml
@@ -7,6 +7,16 @@
    <extension-point id="liclipse_color_cache_provider" name="LiClipse Color Cache Provider" schema="schema/liclipse_color_cache_provider.exsd"/>
    <extension-point id="liclipse_editor_customizer" name="LiClipse Editor Customizer" schema="schema/liclipse_editor_customizer.exsd"/>
 
+    <extension
+          point="org.eclipse.core.contenttype.contentTypes">
+       <content-type
+             base-type="org.eclipse.core.runtime.text"
+             id="org.brainwy.liclipsetext.contentType"
+             name="Supported by Liclipse"
+             priority="normal">
+       </content-type>
+    </extension>
+
    <!-- editor -->
    <extension point="org.eclipse.ui.editors">
       <editor
@@ -18,7 +28,7 @@
             id="com.brainwy.liclipse.editor.common.LiClipseEditor"
             name="Liclipse Editor">
          <contentTypeBinding
-               contentTypeId="org.eclipse.core.runtime.text">
+               contentTypeId="org.brainwy.liclipsetext.contentType">
          </contentTypeBinding>
       </editor>
    </extension>
@@ -163,7 +173,7 @@
     EDITORS_LST = [{'kind': 'html', 'ext': 'html,htm', 'img': 'html'}, {'kind': 'xml', 'base_type': 'org.eclipse.core.runtime.xml', 'ext': 'xml,xsd', 'img': 'xml', 'filenames': '.pydevproject,.project,.classpath'}, {'kind': 'javascript', 'ext': 'js', 'img': 'javascript'}, {'kind': 'java', 'ext': 'java', 'img': 'java'}, {'kind': 'liclipse', 'ext': 'liclipse', 'img': 'liclipse'}, {'kind': 'django', 'ext': 'djhtml', 'img': 'django'}, {'kind': 'python', 'ext': 'py,pyw', 'img': 'python', 'filenames': 'SConstruct,Sconstruct,sconstruct,SConscript'}, {'kind': 'cpp', 'ext': 'c,cpp,h,hpp', 'img': 'cpp'}, {'kind': 'source.css', 'ext': 'css', 'img': 'css'}, {'kind': 'source.scss', 'ext': 'scss', 'img': 'scss'}, {'kind': 'coffeescript', 'ext': 'coffee', 'img': 'coffee'}, {'kind': 'restructured text', 'ext': 'rst', 'img': 'rst'}, {'kind': 'dart', 'ext': 'dart', 'img': 'dart'}, {'kind': 'mako', 'ext': 'mako', 'img': 'mako'}, {'kind': 'xgui20', 'ext': 'xgui2,xgui2_', 'img': 'liclipse'}, {'kind': 'kivy', 'ext': 'kv', 'img': 'kivy'}, {'kind': 'julia', 'ext': 'jl', 'img': 'julia'}, {'kind': 'stringtemplate', 'ext': 'st,stg', 'img': 'stringtemplate'}, {'kind': 'yaml', 'ext': 'yml,yaml,liclipseprefs', 'img': 'yaml'}, {'kind': 'nim', 'ext': 'nim', 'img': 'nim'}, {'kind': 'go', 'ext': 'go', 'img': 'go'}, {'kind': 'jinja2', 'ext': 'jinja2', 'img': 'jinja2'}, {'kind': 'source.ruby', 'ext': 'rb,rbx,Rakefile,rake', 'img': 'source.ruby'}, {'kind': 'text.html.erb', 'ext': 'erb,rhtml,html.erb', 'img': 'text.html.erb'}, {'kind': 'text.html.php', 'ext': 'php,php3,php4,php5,phpt,phtml,aw,ctp', 'img': 'text.html.php'}, {'kind': 'text.html.markdown', 'ext': 'md,mdown,markdown,markdn', 'img': 'text.html.markdown'}, {'kind': 'source.swift', 'ext': 'swift', 'img': 'source.swift'}, {'kind': 'source.perl', 'ext': 'pl,pm,pod,t,PL,psgi', 'img': 'source.perl'}, {'kind': 'source.perl.6', 'ext': 'p6,pl6,pm6,nqp', 'img': 'source.perl.6'}, {'kind': 'source.dosbatch', 'ext': 'bat', 'img': 'source.dosbatch'}, {'kind': 'source.shell', 'ext': 'sh,bash,zsh,bashrc,bash_profile,bash_login,profile,bash_logout,textmate_init', 'img': 'source.shell'}, {'kind': 'source.raml', 'ext': 'raml', 'img': 'source.raml'}, {'kind': 'source.cmake', 'ext': 'cmake', 'img': 'source.cmake', 'filenames': 'CMakeLists.txt,cmake'}, {'kind': 'source.cache.cmake', 'ext': 'cmakecache', 'img': 'source.cache.cmake', 'filenames': 'CMakeCache.txt'}]
     for x in EDITORS_LST:
         if 'base_type' not in x:
-            x['base_type'] = 'org.eclipse.core.runtime.text'
+            x['base_type'] = 'org.brainwy.liclipsetext.contentType'
         x['kind_upper'] = x['kind'].title().replace(' ', '').replace('.', '')
         if 'filenames' not in x:
         	x['filenames'] = ''
@@ -172,7 +182,7 @@
     ]]]-->
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="html,htm" file-names=""
             id="com.brainwy.liclipse.html" name="Html File" priority="normal"/>
     </extension>
@@ -258,7 +268,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="js" file-names=""
             id="com.brainwy.liclipse.javascript" name="Javascript File" priority="normal"/>
     </extension>
@@ -301,7 +311,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="java" file-names=""
             id="com.brainwy.liclipse.java" name="Java File" priority="normal"/>
     </extension>
@@ -344,7 +354,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="liclipse" file-names=""
             id="com.brainwy.liclipse.liclipse" name="Liclipse File" priority="normal"/>
     </extension>
@@ -387,7 +397,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="djhtml" file-names=""
             id="com.brainwy.liclipse.django" name="Django File" priority="normal"/>
     </extension>
@@ -430,7 +440,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="py,pyw" file-names="SConstruct,Sconstruct,sconstruct,SConscript"
             id="com.brainwy.liclipse.python" name="Python File" priority="normal"/>
     </extension>
@@ -473,7 +483,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="c,cpp,h,hpp" file-names=""
             id="com.brainwy.liclipse.cpp" name="Cpp File" priority="normal"/>
     </extension>
@@ -516,7 +526,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="css" file-names=""
             id="com.brainwy.liclipse.source.css" name="SourceCss File" priority="normal"/>
     </extension>
@@ -559,7 +569,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="scss" file-names=""
             id="com.brainwy.liclipse.source.scss" name="SourceScss File" priority="normal"/>
     </extension>
@@ -602,7 +612,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="coffee" file-names=""
             id="com.brainwy.liclipse.coffeescript" name="Coffeescript File" priority="normal"/>
     </extension>
@@ -645,7 +655,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="rst" file-names=""
             id="com.brainwy.liclipse.restructured text" name="RestructuredText File" priority="normal"/>
     </extension>
@@ -688,7 +698,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="dart" file-names=""
             id="com.brainwy.liclipse.dart" name="Dart File" priority="normal"/>
     </extension>
@@ -731,7 +741,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="mako" file-names=""
             id="com.brainwy.liclipse.mako" name="Mako File" priority="normal"/>
     </extension>
@@ -774,7 +784,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="xgui2,xgui2_" file-names=""
             id="com.brainwy.liclipse.xgui20" name="Xgui20 File" priority="normal"/>
     </extension>
@@ -817,7 +827,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="kv" file-names=""
             id="com.brainwy.liclipse.kivy" name="Kivy File" priority="normal"/>
     </extension>
@@ -860,7 +870,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="jl" file-names=""
             id="com.brainwy.liclipse.julia" name="Julia File" priority="normal"/>
     </extension>
@@ -903,7 +913,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="st,stg" file-names=""
             id="com.brainwy.liclipse.stringtemplate" name="Stringtemplate File" priority="normal"/>
     </extension>
@@ -946,7 +956,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="yml,yaml,liclipseprefs" file-names=""
             id="com.brainwy.liclipse.yaml" name="Yaml File" priority="normal"/>
     </extension>
@@ -989,7 +999,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="nim" file-names=""
             id="com.brainwy.liclipse.nim" name="Nim File" priority="normal"/>
     </extension>
@@ -1032,7 +1042,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="go" file-names=""
             id="com.brainwy.liclipse.go" name="Go File" priority="normal"/>
     </extension>
@@ -1075,7 +1085,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="jinja2" file-names=""
             id="com.brainwy.liclipse.jinja2" name="Jinja2 File" priority="normal"/>
     </extension>
@@ -1118,7 +1128,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="rb,rbx,Rakefile,rake" file-names=""
             id="com.brainwy.liclipse.source.ruby" name="SourceRuby File" priority="normal"/>
     </extension>
@@ -1161,7 +1171,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="erb,rhtml,html.erb" file-names=""
             id="com.brainwy.liclipse.text.html.erb" name="TextHtmlErb File" priority="normal"/>
     </extension>
@@ -1204,7 +1214,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="php,php3,php4,php5,phpt,phtml,aw,ctp" file-names=""
             id="com.brainwy.liclipse.text.html.php" name="TextHtmlPhp File" priority="normal"/>
     </extension>
@@ -1247,7 +1257,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="md,mdown,markdown,markdn" file-names=""
             id="com.brainwy.liclipse.text.html.markdown" name="TextHtmlMarkdown File" priority="normal"/>
     </extension>
@@ -1290,7 +1300,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="swift" file-names=""
             id="com.brainwy.liclipse.source.swift" name="SourceSwift File" priority="normal"/>
     </extension>
@@ -1333,7 +1343,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="pl,pm,pod,t,PL,psgi" file-names=""
             id="com.brainwy.liclipse.source.perl" name="SourcePerl File" priority="normal"/>
     </extension>
@@ -1376,7 +1386,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="p6,pl6,pm6,nqp" file-names=""
             id="com.brainwy.liclipse.source.perl.6" name="SourcePerl6 File" priority="normal"/>
     </extension>
@@ -1419,7 +1429,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="bat" file-names=""
             id="com.brainwy.liclipse.source.dosbatch" name="SourceDosbatch File" priority="normal"/>
     </extension>
@@ -1462,7 +1472,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="sh,bash,zsh,bashrc,bash_profile,bash_login,profile,bash_logout,textmate_init" file-names=""
             id="com.brainwy.liclipse.source.shell" name="SourceShell File" priority="normal"/>
     </extension>
@@ -1505,7 +1515,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="raml" file-names=""
             id="com.brainwy.liclipse.source.raml" name="SourceRaml File" priority="normal"/>
     </extension>
@@ -1548,7 +1558,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="cmake" file-names="CMakeLists.txt,cmake"
             id="com.brainwy.liclipse.source.cmake" name="SourceCmake File" priority="normal"/>
     </extension>
@@ -1591,7 +1601,7 @@
 
     <!-- Note: run the install.py to regenerate the actions contents! -->
     <extension point="org.eclipse.core.contenttype.contentTypes">
-        <content-type base-type="org.eclipse.core.runtime.text"
+        <content-type base-type="org.brainwy.liclipsetext.contentType"
             file-extensions="cmakecache" file-names="CMakeCache.txt"
             id="com.brainwy.liclipse.source.cache.cmake" name="SourceCacheCmake File" priority="normal"/>
     </extension>
@@ -1920,6 +1930,14 @@
 
     <extension point="org.brainwy.liclipsetext.editor.liclipse_error_collector">
         <error_collector_participant class="org.brainwy.liclipsetext.editor.error_handling.LiClipseLanguageErrorCollector"/>
+    </extension>
+    
+    <extension
+          point="org.eclipse.ui.genericeditor.presentationReconcilers">
+       <presentationReconciler
+             class="org.brainwy.liclipsetext.editor.common.partitioning.LiclipsePresentationReconcilierExt"
+             contentType="org.brainwy.liclipsetext.contentType">
+       </presentationReconciler>
     </extension>
 
 </plugin>

--- a/plugins/org.brainwy.liclipsetext.editor/src/org/brainwy/liclipsetext/editor/common/partitioning/LiclipsePresentationReconcilierExt.java
+++ b/plugins/org.brainwy.liclipsetext.editor/src/org/brainwy/liclipsetext/editor/common/partitioning/LiclipsePresentationReconcilierExt.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016 Red Hat Inc.
+ * Licensed under the terms of the Eclipse Public License (EPL).
+ * Please see the license.txt included with this distribution for details.
+ * Any modifications to this file must keep this entire header intact.
+ */
+package org.brainwy.liclipsetext.editor.common.partitioning;
+
+import org.brainwy.liclipsetext.editor.LiClipseTextEditorPlugin;
+import org.brainwy.liclipsetext.editor.languages.LanguagesManager;
+import org.brainwy.liclipsetext.editor.languages.LiClipseLanguage;
+import org.brainwy.liclipsetext.editor.preferences.LiClipseTextPreferences;
+import org.eclipse.core.filebuffers.ITextFileBufferManager;
+import org.eclipse.jface.text.DocumentEvent;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.ITypedRegion;
+import org.eclipse.jface.text.TextPresentation;
+import org.eclipse.jface.text.presentation.IPresentationDamager;
+import org.eclipse.jface.text.presentation.IPresentationReconciler;
+import org.eclipse.jface.text.presentation.IPresentationRepairer;
+import org.eclipse.jface.text.presentation.PresentationReconciler;
+
+public class LiclipsePresentationReconcilierExt extends PresentationReconciler {
+	
+	public class LiclipseDelegatePresentationDamager implements IPresentationDamager, IPresentationRepairer {
+
+		@Override
+		public void setDocument(IDocument document) {
+			initializeDelegateReconcilier(document);
+		}
+
+		@Override
+		public IRegion getDamageRegion(ITypedRegion partition, DocumentEvent event,
+				boolean documentPartitioningChanged) {
+			if (delegate == null && viewer.getDocument() != null) {
+				initializeDelegateReconcilier(viewer.getDocument());
+			}
+			if (delegate != null) {
+				return delegate.getDamager(partition.getType()).getDamageRegion(partition, event, documentPartitioningChanged);
+			} else {
+				return null;
+			}
+		}
+
+		@Override
+		public void createPresentation(TextPresentation presentation, ITypedRegion damage) {
+			if (delegate == null && viewer.getDocument() != null) {
+				initializeDelegateReconcilier(viewer.getDocument());
+			}
+			if (delegate != null) {
+				delegate.getRepairer(damage.getType()).createPresentation(presentation, damage);
+			}
+		}
+
+	}
+
+	private LiClipseDocumentPartitioner partitioner;
+	private IPresentationReconciler delegate;
+	private Object currentDocument;
+	private ITextViewer viewer;
+	private boolean inProgress;
+
+	public LiclipsePresentationReconcilierExt() {
+		LiclipseDelegatePresentationDamager damager = new LiclipseDelegatePresentationDamager();
+		setDamager(damager, IDocument.DEFAULT_CONTENT_TYPE);
+		setRepairer(damager, IDocument.DEFAULT_CONTENT_TYPE);
+	}
+	
+	@Override
+	public void install(ITextViewer viewer) {
+		this.viewer = viewer;
+		super.install(viewer);
+	}
+	
+	private IPresentationReconciler initializeDelegateReconcilier(IDocument document) {
+		if (!inProgress && document != null && document != this.currentDocument) {
+			inProgress = true;
+			this.currentDocument = document;
+			String fileName = ITextFileBufferManager.DEFAULT.getTextFileBuffer(document).getLocation().lastSegment();
+		    LanguagesManager languagesManager = LiClipseTextEditorPlugin.getLanguagesManager();
+			LiClipseLanguage language = languagesManager.getLanguageForFilename(fileName);
+			this.partitioner = language.connect(document);
+			this.delegate = partitioner.getPresentationReconciler(new LiClipseColorCache(LiClipseTextPreferences.getChainedPreferenceStore()));
+			delegate.install(viewer);
+			inProgress = false;
+		}
+		return this.delegate;
+	}
+
+	
+	@Override
+	public void uninstall() {
+		if (this.delegate != null) {
+			this.delegate.uninstall();
+			this.delegate = null;
+		}
+		if (this.partitioner != null) {
+			this.partitioner.disconnect();
+			this.partitioner = null;
+		}
+	}
+
+}

--- a/plugins/org.brainwy.liclipsetext.editor/src/org/brainwy/liclipsetext/editor/templates/LiClipseDocumentTemplateContext.java
+++ b/plugins/org.brainwy.liclipsetext.editor/src/org/brainwy/liclipsetext/editor/templates/LiClipseDocumentTemplateContext.java
@@ -1,44 +1,51 @@
 /**
- * Copyright (c) 2013-2016 by Brainwy Software Ltda. All Rights Reserved.
+ * Copyright (c) 2013-2016 by Brainwy Software Ltda, and others.
+ * All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
  */
 package org.brainwy.liclipsetext.editor.templates;
 
-import org.eclipse.jface.text.BadLocationException;
-import org.eclipse.jface.text.IDocument;
-import org.eclipse.jface.text.templates.TemplateContextType;
 import org.brainwy.liclipsetext.editor.common.ILiClipseEditor;
 import org.brainwy.liclipsetext.editor.languages.LiClipseLanguage;
 import org.brainwy.liclipsetext.shared_core.log.Log;
 import org.brainwy.liclipsetext.shared_core.string.TextSelectionUtils;
 import org.brainwy.liclipsetext.shared_ui.templates.AbstractDocumentTemplateContextWithIndent;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.templates.TemplateContextType;
 
 public class LiClipseDocumentTemplateContext extends AbstractDocumentTemplateContextWithIndent {
 
-    private ILiClipseEditor editor;
+	private LiClipseLanguage language;
     public String prefix;
     public String prefixWithSeparators;
 
     public LiClipseDocumentTemplateContext(TemplateContextType type, IDocument document, int offset, int length,
             String indentTo, ILiClipseEditor editor) {
         super(type, document, offset, length, indentTo);
-        this.editor = editor;
+        this.language = editor.getLiClipseLanguage();
     }
 
-    @Override
+    public LiClipseDocumentTemplateContext(TemplateContextType type, IDocument document,
+			int offset, int length, String indentTo, LiClipseLanguage language) {
+        super(type, document, offset, length, indentTo);
+        this.language = language;
+	}
+
+	@Override
     protected int getTabWidth() {
-        return editor.getLiClipseLanguage().getIndent().getTabWidth();
+        return language.getIndent().getTabWidth();
     }
 
     @Override
     protected boolean getUseSpaces() {
-        return editor.getLiClipseLanguage().getIndent().getTabsToSpaceEnabled();
+        return language.getIndent().getTabsToSpaceEnabled();
     }
 
     public TextSelectionUtils createTextSelectionUtils() {
-        return editor.createTextSelectionUtils();
+    	return new TextSelectionUtils(getDocument(), getCompletionOffset());
     }
 
     public TextSelectionUtils markSelection() {
@@ -70,7 +77,7 @@ public class LiClipseDocumentTemplateContext extends AbstractDocumentTemplateCon
     }
 
     public LiClipseLanguage getLanguage() {
-        return editor.getLiClipseLanguage();
+        return this.language;
     }
 
     /**

--- a/plugins/org.brainwy.liclipsetext.editor/src/org/brainwy/liclipsetext/editor/templates/LiClipseTemplateCompletionProcessor.java
+++ b/plugins/org.brainwy.liclipsetext.editor/src/org/brainwy/liclipsetext/editor/templates/LiClipseTemplateCompletionProcessor.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2013-2016 by Brainwy Software Ltda. All Rights Reserved.
+ * =Copyright (c) 2013-2016 by Brainwy Software Ltda, and others.
+ * All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -374,8 +375,7 @@ public final class LiClipseTemplateCompletionProcessor {// implements IContentAs
         }
 
         //This would be the super call, but we want to use our language to say which are the separators.
-        LiClipseDocumentPartitioner partitioner = ((LiClipseDocumentPartitioner) document.getDocumentPartitioner());
-        Set<Character> separatorChars = partitioner.language.getSeparatorChars();
+        Set<Character> separatorChars = liClipseLanguage.getSeparatorChars();
 
         int i = offset;
         if (i > document.getLength()) {
@@ -417,18 +417,12 @@ public final class LiClipseTemplateCompletionProcessor {// implements IContentAs
 
     protected LiClipseDocumentTemplateContext createContext(final ITextViewer viewer, final IRegion region) {
         Assert.isNotNull(liClipseTemplateContextType);
-        if (!(viewer instanceof ILiClipseSourceViewer)) {
-            Log.log("Expecting ILiClipseSourceViewer. Found: " + viewer);
-            return null;
-        }
-        ILiClipseSourceViewer liClipseSourceViewer = (ILiClipseSourceViewer) viewer;
-        ILiClipseEditor editor = liClipseSourceViewer.getLiClipseEditor();
 
         IDocument document = viewer.getDocument();
         TextSelectionUtils ts = new TextSelectionUtils(document, viewer.getSelectedRange().x);
         String indent = ts.getIndentationFromLine();
         return new LiClipseDocumentTemplateContext(liClipseTemplateContextType, document, region.getOffset(),
-                region.getLength(), indent, editor);
+                region.getLength(), indent, this.liClipseLanguage);
     }
 
 }


### PR DESCRIPTION
This contribute Liclipse based extensions to generic Text Editor.
Most of the work is to allow to plug the partitionner during/after
editor initialization.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=496117
Signed-off-by: Mickael Istria <mistria@redhat.com>